### PR TITLE
Fix wavrec appending the end of one recording to the next file

### DIFF
--- a/commander.sh
+++ b/commander.sh
@@ -97,7 +97,7 @@ record() {
   mhacontrol "mha.transducers.mhachain.record.record = yes"
   sleep "$DURATION"
   mhacontrol "mha.transducers.mhachain.record.record = no"
-  cp "/dev/shm/recording.wav" "$TARGETFILE"
+  mv "/dev/shm/recording.wav" "$TARGETFILE"
 }
 
 while true ; do


### PR DESCRIPTION
The problem with corrupted recording is probably a thread-safety
issue. In  unixoid systems 'mv' is generally atomic while 'cp'
is not.